### PR TITLE
Fixed ingest errors on non content serving requests

### DIFF
--- a/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
+++ b/packages/apache_tomcat/data_stream/access/elasticsearch/ingest_pipeline/default.yml
@@ -42,7 +42,7 @@ processors:
       field: _tmp.dissectgrok
       tag: 'grok_parse_log_dissectgrok'
       patterns:
-        - '^%{NUMBER:http.response.status_code} %{POSINT:destination.bytes}( %{GREEDYDATA:_tmp.grok})?$'
+        - '^%{NUMBER:http.response.status_code} (-%{POSINT:destination.bytes})( %{GREEDYDATA:_tmp.grok})?$'
       on_failure:
         - append:
             field: error.message


### PR DESCRIPTION
When parsing for example a 302 request, the response-bytes are "-" and therefore, the grok processor throwed an error. This should now be fixed.

## Proposed commit message

<!-- Mandatory
Explain here the changes you made on the PR.

When parsing for example a 302 request, the response-bytes are "-" and therefore, the grok processor throwed an error. This should now be fixed.

## Checklist

- [ ] I have reviewed [tips for building integrations](https://github.com/elastic/integrations/blob/main/docs/tips_for_building_integrations.md) and this pull request is aligned with them.
- [ ] I have verified that all data streams collect metrics or logs.
- [ ] I have added an entry to my package's `changelog.yml` file.
- [ ] I have verified that Kibana version constraints are current according to [guidelines](https://github.com/elastic/elastic-package/blob/master/docs/howto/stack_version_support.md#when-to-update-the-condition).
